### PR TITLE
Updated Dashboard, External CSS File, Filter by Author

### DIFF
--- a/classes/class-linker-cpt.php
+++ b/classes/class-linker-cpt.php
@@ -110,23 +110,6 @@ class Linker_CPT {
 		);
 	}
 
-	public function admin_header() {
-		// TODO: move to a separate file.
-		?><style>
-			#adminmenu #menu-posts-linker div.wp-menu-image:before {
-				content: "\f103";
-			}
-			.fixed .column-linker_clicks {
-				width: 10%;
-			}
-			#linker_dashboard_widget tr td.border-bottom {
-				padding: 4px 0 4px 0;
-				border-bottom:1pt solid #dddddd;
-			}
-		</style>
-	<?php
-	}
-
 	public function render_meta_box( $post ) {
 		wp_nonce_field( basename( __FILE__ ), '_linker_meta_box_nonce' );
 		
@@ -177,35 +160,38 @@ class Linker_CPT {
 		
 		die();
 	}
-	
-	// Add Dashboard Widget for Linker
+
+	/**
+	 * Add Dashboard Widget for Linker
+	 */
 	public function linker_add_dashboard_widget() {
-	
-		wp_add_dashboard_widget( 'linker_dashboard_widget', __( 'Linker Top 10 Clicks', 'link-click-monitor' ), array(
-			$this,
-			'linker_dashboard_widget_function'
-		) );	
+		wp_add_dashboard_widget(
+			'linker_dashboard_widget',
+			__( 'Linker - Top 10', 'linker' ),
+			array( &$this, 'linker_dashboard_widget_function' )
+		);	
 	}
 
-	// Add Dashboard Function for Linker
+	/**
+	 * Add Dashboard Function for Linker
+	 */
 	public function linker_dashboard_widget_function() {
-	
-		$posts = get_posts(array(
-		'post_type'   => 'linker',
-		'post_status' => 'publish',
-		'posts_per_page' => -1,
-		'fields' => 'ids',
-		'meta_key' => '_linker_count',
-		'orderby' => 'meta_value_num',
-		'order' => 'DESC',
-		'posts_per_page' => 10,
-		));
+		$posts = get_posts(
+			array(
+				'post_type' => 'linker',
+				'post_status' => 'publish',
+				'fields' => 'ids',
+				'meta_key' => '_linker_count',
+				'orderby' => 'meta_value_num',
+				'order' => 'DESC',
+				'posts_per_page' => 10,
+			)
+		);
 		
 		if ( empty( $posts ) ) {
-			echo '<p>' . __( 'There are no stats available yet!', 'link-click-monitor' ) . '</p>';
+			echo '<p>' . __( 'There are no stats available yet!', 'linker' ) . '</p>';
 			return;
 		}
-		
 		?>
 		<table width="100%" border="0" cellspacing="0" cellpadding="0">
 			<thead>
@@ -231,26 +217,36 @@ class Linker_CPT {
 			<?php endforeach; ?>
 			</tbody>
 		</table>
-        <?php
+		<?php
 	}
-	
-	// Add order by Clicks
+
+	/**
+	 * Add order by Clicks
+	 * 
+	 * @param array $columns
+	 *
+	 * @return array
+	 */
 	public function sortable_linker_clicks_column( $columns ) {
 		$columns['linker_clicks'] = 'linker_clicks';
-	 
+
 		return $columns;
 	}
-	
-	// Add order by Clicks
+
+	/**
+	 * Add order by Clicks
+	 * 
+	 * @param WP_Query $query
+	 */
 	public function clicks_orderby( $query ) {
-		if( ! is_admin() )
+		if ( ! is_admin() )
 			return;
-	 
-		$orderby = $query->get( 'orderby');
-	 
-		if( 'linker_clicks' == $orderby ) {
-			$query->set('meta_key','_linker_count');
-			$query->set('orderby','meta_value_num');
+
+		$orderby = $query->get( 'orderby' );
+
+		if ( 'linker_clicks' == $orderby ) {
+			$query->set( 'meta_key', '_linker_count' );
+			$query->set( 'orderby', 'meta_value_num' );
 		}
 	}
 	
@@ -267,12 +263,19 @@ class Linker_CPT {
             }
 	}
 	
+	// Add external CSS Stylesheet file
+	public function dashboard_widget_linker_external_css( $hook ) {
+		if( 'index.php' != $hook ) {
+			return;
+		}
+	wp_enqueue_style( 'dashboard-widget-styles', plugins_url( '', __FILE__ ) . '/linker-styles.css' );
+	}
+	
 	public function __construct() {
 		// TODO: please add updated messages
 		
 		add_action( 'init', array( &$this, 'register_post_type' ) );
 		add_action( 'admin_menu', array( &$this, 'register_meta_box' ) );
-		add_action( 'admin_head', array( &$this, 'admin_header' ) );
 		add_filter( 'plugin_action_links_' . LINKER_BASE, array( &$this, 'plugin_action_links' ) );
 		
 		add_filter( 'manage_edit-linker_columns', array( &$this, 'admin_cpt_columns' ) );
@@ -289,6 +292,9 @@ class Linker_CPT {
 		
 		// Add filter by Author
 		add_action('restrict_manage_posts', array( &$this, 'linker_filter_by_author') );
+		
+		// Add external CSS Stylesheet file
+		add_action( 'admin_enqueue_scripts', array( &$this, 'dashboard_widget_linker_external_css' ));
 	}
 	
 }

--- a/classes/class-linker-cpt.php
+++ b/classes/class-linker-cpt.php
@@ -252,6 +252,19 @@ class Linker_CPT {
 		}
 	}
 	
+	// Add filter by Author
+	public function linker_filter_by_author() {
+
+		global $typenow;
+            if ($typenow=='linker') {
+				$args = array('name' => 'author', 'show_option_all' => 'View all authors');
+				if (isset($_GET['user'])) {
+					$args['selected'] = $_GET['user'];
+				}
+				wp_dropdown_users($args);
+            }
+	}
+	
 	public function __construct() {
 		// TODO: please add updated messages
 		
@@ -271,6 +284,9 @@ class Linker_CPT {
 		// Add order by Clicks
 		add_action( 'pre_get_posts', array( &$this, 'clicks_orderby' ) );
 		add_filter( 'manage_edit-linker_sortable_columns', array( &$this, 'sortable_linker_clicks_column' ) );
+		
+		// Add filter by Author
+		add_action('restrict_manage_posts', array( &$this, 'linker_filter_by_author') );
 	}
 	
 }

--- a/classes/class-linker-cpt.php
+++ b/classes/class-linker-cpt.php
@@ -119,6 +119,10 @@ class Linker_CPT {
 			.fixed .column-linker_clicks {
 				width: 10%;
 			}
+			#linker_dashboard_widget tr td.border-bottom {
+				padding: 4px 0 4px 0;
+				border-bottom:1pt solid #dddddd;
+			}
 		</style>
 	<?php
 	}
@@ -205,28 +209,26 @@ class Linker_CPT {
 		?>
 		<table width="100%" border="0" cellspacing="0" cellpadding="0">
 			<thead>
-				<tr>
-					<th align="left" scope="col"><?php _e( 'Redirect to', "link-click-monitor" ); ?></th>
-                    <th align="left" scope="col"><?php _e( 'Edit', "link-click-monitor" ); ?></th>
-                    <th align="left" scope="col"><?php _e( 'Clicks', "link-click-monitor" ); ?></th>
-				</tr>
+			<tr align="<?php echo is_rtl() ? 'right' : 'left'; ?>">
+				<th scope="col"><?php _e( 'Redirect to', 'linker' ); ?></th>
+				<th scope="col"><?php _e( 'Edit', 'linker' ); ?></th>
+				<th scope="col"><?php _e( 'Clicks', 'linker' ); ?></th>
+			</tr>
 			</thead>
 			<tbody>
- 				<?php
-				//loop over each post
-				foreach($posts as $p){
-				//get the meta you need from each post
-				$link = get_post_meta($p,"_linker_redirect",true);
-				$link_count = get_post_meta($p,"_linker_count",true);
+			<?php
+			//loop over each post
+			foreach ( $posts as $post_id ) :
+				// Get the meta you need from each post
+				$link       = get_post_meta( $post_id, '_linker_redirect', true );
+				$link_count = absint( get_post_meta( $post_id, '_linker_count', true ) );
 				?>
-                <tr>
-					<td><a target="_blank" href="<?php echo $link;?>"><?php echo $link;?></a></td>
-                    <td><a href="<?php echo admin_url();?>post.php?post=<?php echo $p;?>&action=edit">Edit</a></td>
-					<td><?php echo $link_count;?></td>
+				<tr>
+					<td class="border-bottom" scope="row"><strong><?php echo get_the_title( $post_id ); ?></strong><br /><a target="_blank" href="<?php echo $link; ?>"><?php echo $link; ?></a></td>
+					<td class="border-bottom" scope="row"><a href="<?php echo get_edit_post_link( $post_id ); ?>"><?php _e( 'Edit', 'linker' ); ?></a></td>
+					<td class="border-bottom" scope="row"><?php echo $link_count; ?></td>
 				</tr>
-                <?php
-				}
-				?>
+			<?php endforeach; ?>
 			</tbody>
 		</table>
         <?php

--- a/classes/linker-styles.css
+++ b/classes/linker-styles.css
@@ -1,0 +1,12 @@
+@charset "UTF-8";
+/* CSS Document */
+#adminmenu #menu-posts-linker div.wp-menu-image:before {
+	content: "\f103";
+}
+.fixed .column-linker_clicks {
+	width: 10%;
+}
+#linker_dashboard_widget tr td.border-bottom {
+	padding: 4px 0 4px 0;
+	border-bottom:1pt solid #dddddd;
+}


### PR DESCRIPTION
Updated the Dashboard to show the linker post title - Incase 2 link urls (i.e. /go/same-url-V1/ and  /go/same-url-V2/) goto the same url.

Now uses an external CSS file based in the folder (wp-linker/classes/linker-styles).

Can filter by Author on the listings page.